### PR TITLE
fix ModelName methods

### DIFF
--- a/lib/Model/ModelOperation.php
+++ b/lib/Model/ModelOperation.php
@@ -242,7 +242,7 @@ class ModelOperation implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getMergeModelName()
     {
         return $this->container['model_name'];
     }
@@ -254,7 +254,7 @@ class ModelOperation implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return self
      */
-    public function setModelName($model_name)
+    public function setMergeModelName($model_name)
     {
         $this->container['model_name'] = $model_name;
 

--- a/lib/Model/SyncStatus.php
+++ b/lib/Model/SyncStatus.php
@@ -260,7 +260,7 @@ class SyncStatus implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getMergeModelName()
     {
         return $this->container['model_name'];
     }
@@ -272,7 +272,7 @@ class SyncStatus implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return self
      */
-    public function setModelName($model_name)
+    public function setMergeModelName($model_name)
     {
         $this->container['model_name'] = $model_name;
 


### PR DESCRIPTION
## Description of the change

We see in https://github.com/OpenAPITools/openapi-generator/blob/v5.1.1/modules/openapi-generator/src/main/resources/php/model_generic.mustache#L121 that the openapi-generator for every model has a `getModelName()` method. However, if you have a property also called `model_name` like two of our models do, then it ends up in conflict and two `getModelName()` methods get defined.

We rename `get/set` `ModelName()` to `get/set MergeModelName()`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.


